### PR TITLE
Update for some deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,14 +37,16 @@
     "pre-commit": "1.x",
     "rc-server": "3.x",
     "rc-tools": "4.x",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "~0.14.0",
-    "react-dom": "~0.14.0"
+    "react": "15.x",
+    "react-addons-test-utils": "15.x",
+    "react-dom": "15.x"
   },
   "pre-commit": [
     "lint"
   ],
   "dependencies": {
-    "classnames": "^2.2.1"
+    "create-react-class": "15.x",
+    "classnames": "2.x",
+    "prop-types": "15.x"
   }
 }

--- a/src/Switch.jsx
+++ b/src/Switch.jsx
@@ -1,18 +1,20 @@
 const React = require('react');
+const PropTypes = require('prop-types');
+const createReactClass = require('create-react-class');
 const classNames = require('classnames');
 
 function noop() {
 }
 
-const Switch = React.createClass({
+const Switch = createReactClass({
   propTypes: {
-    className: React.PropTypes.string,
-    prefixCls: React.PropTypes.string,
-    disabled: React.PropTypes.bool,
-    checkedChildren: React.PropTypes.any,
-    unCheckedChildren: React.PropTypes.any,
-    onChange: React.PropTypes.func,
-    onMouseUp: React.PropTypes.func,
+    className: PropTypes.string,
+    prefixCls: PropTypes.string,
+    disabled: PropTypes.bool,
+    checkedChildren: PropTypes.any,
+    unCheckedChildren: PropTypes.any,
+    onChange: PropTypes.func,
+    onMouseUp: PropTypes.func,
   },
   getDefaultProps() {
     return {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -5,7 +5,7 @@ const expect = require('expect.js');
 const Switch = require('../index');
 const React = require('react');
 const ReactDOM = require('react-dom');
-const TestUtils = require('react-addons-test-utils');
+const TestUtils = require('react-dom/test-utils');
 const Simulate = TestUtils.Simulate;
 
 describe('rc-switch', () => {
@@ -26,7 +26,7 @@ describe('rc-switch', () => {
 
   it('works', () =>{
     expect(switcher.state.checked).to.be(false);
-    Simulate.click(React.findDOMNode(switcher));
+    Simulate.click(ReactDOM.findDOMNode(switcher));
     expect(switcher.state.checked).to.be(true);
   });
 });


### PR DESCRIPTION
Hi rc-switch committers,

I have updated this library for some deprecation warnings.
rc-swich is written in without es6, so I think it's a temporaly fix.
But could you merge this?

Thanks,
