### PR TITLE
Added support for custom tabIndex.

### DIFF
--- a/src/Switch.jsx
+++ b/src/Switch.jsx
@@ -61,8 +61,9 @@ class Switch extends Component {
 
   render() {
     const { className, prefixCls, disabled,
-      checkedChildren, unCheckedChildren, ...restProps } = this.props;
+      checkedChildren, tabIndex, unCheckedChildren, ...restProps } = this.props;
     const checked = this.state.checked;
+    const switchTabIndex = disabled ? -1 : (tabIndex || 0);
     const switchClassName = classNames({
       [className]: !!className,
       [prefixCls]: true,
@@ -73,7 +74,7 @@ class Switch extends Component {
       <span
         {...restProps}
         className={switchClassName}
-        tabIndex={disabled ? -1 : 0}
+        tabIndex={switchTabIndex}
         ref="node"
         onKeyDown={this.handleKeyDown.bind(this)}
         onClick={disabled ? noop : this.toggle.bind(this)}
@@ -95,6 +96,7 @@ Switch.propTypes = {
   unCheckedChildren: PropTypes.any,
   onChange: PropTypes.func,
   onMouseUp: PropTypes.func,
+  tabIndex: PropTypes.number,
   checked: PropTypes.bool,
   defaultChecked: PropTypes.bool,
 };


### PR DESCRIPTION
Now the user can specify a custom tabIndex that will be used when the switch is not disabled. If no tabIndex is specified, the previous behaviour will be preserved ( disabled or not ).