### PR TITLE
support extra node for loading icon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ ReactDOM.render(<Switch />, container);
           <td>whether switch is disabled</td>
         </tr>
         <tr>
-          <td>extra</td>
+          <td>loadingIcon</td>
           <td>React.ReactNode</td>
           <td></td>
           <td>specific the extra node. generally used in loading icon.</td>

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ ReactDOM.render(<Switch />, container);
           <td>false</td>
           <td>whether switch is disabled</td>
         </tr>
+        <tr>
+          <td>extra</td>
+          <td>React.ReactNode</td>
+          <td></td>
+          <td>specific the extra node. generally used in loading icon.</td>
+        </tr>
     </tbody>
 </table>
 

--- a/src/Switch.jsx
+++ b/src/Switch.jsx
@@ -85,7 +85,7 @@ class Switch extends Component {
   }
 
   render() {
-    const { className, prefixCls, disabled,
+    const { className, prefixCls, disabled, extra,
       checkedChildren, tabIndex, unCheckedChildren, ...restProps } = this.props;
     const checked = this.state.checked;
     const switchTabIndex = disabled ? -1 : (tabIndex || 0);
@@ -105,6 +105,7 @@ class Switch extends Component {
         onClick={this.toggle}
         onMouseUp={this.handleMouseUp}
       >
+        {extra}
         <span className={`${prefixCls}-inner`}>
           {checked ? checkedChildren : unCheckedChildren}
         </span>
@@ -126,6 +127,7 @@ Switch.propTypes = {
   checked: PropTypes.bool,
   defaultChecked: PropTypes.bool,
   autoFocus: PropTypes.bool,
+  extra: PropTypes.node,
 };
 
 Switch.defaultProps = {

--- a/src/Switch.jsx
+++ b/src/Switch.jsx
@@ -85,7 +85,7 @@ class Switch extends Component {
   }
 
   render() {
-    const { className, prefixCls, disabled, extra,
+    const { className, prefixCls, disabled, loadingIcon,
       checkedChildren, tabIndex, unCheckedChildren, ...restProps } = this.props;
     const checked = this.state.checked;
     const switchTabIndex = disabled ? -1 : (tabIndex || 0);
@@ -105,7 +105,7 @@ class Switch extends Component {
         onClick={this.toggle}
         onMouseUp={this.handleMouseUp}
       >
-        {extra}
+        {loadingIcon}
         <span className={`${prefixCls}-inner`}>
           {checked ? checkedChildren : unCheckedChildren}
         </span>
@@ -127,7 +127,7 @@ Switch.propTypes = {
   checked: PropTypes.bool,
   defaultChecked: PropTypes.bool,
   autoFocus: PropTypes.bool,
-  extra: PropTypes.node,
+  loadingIcon: PropTypes.node,
 };
 
 Switch.defaultProps = {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -58,6 +58,11 @@ describe('rc-switch', () => {
     expect(onChange.mock.calls.length).toBe(0);
   });
 
+  it('should support extra node', () => {
+    const wrapper = mount(<Switch extra={<span className="extra">extra-node</span>}/>);
+    expect(wrapper.find('.extra').text()).toBe('extra-node');
+  });
+
   it('focus()', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -58,9 +58,9 @@ describe('rc-switch', () => {
     expect(onChange.mock.calls.length).toBe(0);
   });
 
-  it('should support extra node', () => {
-    const wrapper = mount(<Switch extra={<span className="extra">extra-node</span>}/>);
-    expect(wrapper.find('.extra').text()).toBe('extra-node');
+  it('should support loading icon node', () => {
+    const wrapper = mount(<Switch loadingIcon={<span className="extra">loading</span>}/>);
+    expect(wrapper.find('.extra').text()).toBe('loading');
   });
 
   it('focus()', () => {


### PR DESCRIPTION
在inner节点前额外暴露出一个节点，主要用于外部提供loading图标。
配合外部的样式形成loading效果。