### PR TITLE
Add peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0"
   },
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
   "pre-commit": [
     "lint"
   ],


### PR DESCRIPTION
I've added `react` and `react-dom` as a peer dependencies cause it sounds like a correct way and absence of it prevents tools like https://bundlephobia.com/result?p=rc-switch calculate package size