### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,22 +43,19 @@
     ]
   },
   "dependencies": {
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.0",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
+    "@testing-library/react": "^16.0.1",
     "@types/jest": "^29.4.0",
     "@types/node": "^24.5.2",
     "@types/react": "^19.1.14",
     "@types/react-dom": "^19.1.9",
     "@umijs/fabric": "^3.0.0",
-    "cheerio": "1.0.0-rc.12",
     "dumi": "^2.0.0",
-    "enzyme": "^3.0.0",
-    "enzyme-adapter-react-16": "^1.0.1",
-    "enzyme-to-json": "^3.0.0",
     "eslint": "^8.55.0",
     "eslint-plugin-jest": "^27.6.0",
     "eslint-plugin-unicorn": "^49.0.0",
@@ -68,9 +65,8 @@
     "less": "^4.1.3",
     "lint-staged": "^15.1.0",
     "prettier": "^3.1.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-test-renderer": "^16.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "umi-test": "^1.9.7"
   },
   "peerDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode, useControlledState } from '@rc-component/util';
 
 export type SwitchChangeEventHandler = (
   checked: boolean,
@@ -9,8 +8,10 @@ export type SwitchChangeEventHandler = (
 ) => void;
 export type SwitchClickEventHandler = SwitchChangeEventHandler;
 
-interface SwitchProps
-  extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'onChange' | 'onClick'> {
+interface SwitchProps extends Omit<
+  React.HTMLAttributes<HTMLButtonElement>,
+  'onChange' | 'onClick'
+> {
   className?: string;
   prefixCls?: string;
   disabled?: boolean;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,11 +1,15 @@
 import React from 'react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { mount } from 'enzyme';
+import { KeyCode } from '@rc-component/util';
+import { fireEvent, render } from '@testing-library/react';
 import Switch from '..';
 
 describe('rc-switch', () => {
+  function keyDownWithWhich(target, which) {
+    fireEvent.keyDown(target, { keyCode: which });
+  }
+
   function createSwitch(props = {}) {
-    return mount(
+    return render(
       <Switch
         checkedChildren={<span className="checked" />}
         unCheckedChildren={<span className="unchecked" />}
@@ -15,127 +19,140 @@ describe('rc-switch', () => {
   }
 
   it('works', () => {
-    const wrapper = createSwitch();
-    expect(wrapper.exists('.unchecked')).toBeTruthy();
-    wrapper.simulate('click');
-    expect(wrapper.exists('.checked')).toBeTruthy();
+    const { getByRole } = createSwitch();
+    const switchNode = getByRole('switch');
+
+    expect(switchNode.getAttribute('aria-checked')).toBe('false');
+    fireEvent.click(switchNode);
+    expect(switchNode.getAttribute('aria-checked')).toBe('true');
   });
 
   it('should be checked upon right key and unchecked on left key', () => {
-    const wrapper = createSwitch();
-    expect(wrapper.exists('.unchecked')).toBeTruthy();
-    wrapper.simulate('keydown', { which: KeyCode.RIGHT });
-    expect(wrapper.exists('.checked')).toBeTruthy();
-    wrapper.simulate('keydown', { which: KeyCode.LEFT });
-    expect(wrapper.exists('.unchecked')).toBeTruthy();
+    const { getByRole } = createSwitch();
+    const switchNode = getByRole('switch');
+
+    expect(switchNode.getAttribute('aria-checked')).toBe('false');
+    keyDownWithWhich(switchNode, KeyCode.RIGHT);
+    expect(switchNode.getAttribute('aria-checked')).toBe('true');
+    keyDownWithWhich(switchNode, KeyCode.LEFT);
+    expect(switchNode.getAttribute('aria-checked')).toBe('false');
   });
 
   it('should change from an initial checked state of true to false on click', () => {
     const onChange = jest.fn();
-    const wrapper = createSwitch({ defaultChecked: true, onChange });
-    expect(wrapper.exists('.checked')).toBeTruthy();
-    wrapper.simulate('click');
-    expect(wrapper.exists('.unchecked')).toBeTruthy();
+    const { getByRole } = createSwitch({ defaultChecked: true, onChange });
+    const switchNode = getByRole('switch');
+
+    expect(switchNode.getAttribute('aria-checked')).toBe('true');
+    fireEvent.click(switchNode);
+    expect(switchNode.getAttribute('aria-checked')).toBe('false');
     expect(onChange.mock.calls.length).toBe(1);
   });
 
   it('should support onClick', () => {
     const onClick = jest.fn();
-    const wrapper = createSwitch({ onClick });
-    wrapper.simulate('click');
+    const { getByRole } = createSwitch({ onClick });
+    const switchNode = getByRole('switch');
+
+    fireEvent.click(switchNode);
     expect(onClick).toHaveBeenCalledWith(true, expect.objectContaining({ type: 'click' }));
     expect(onClick.mock.calls.length).toBe(1);
-    wrapper.simulate('click');
+    fireEvent.click(switchNode);
     expect(onClick).toHaveBeenCalledWith(false, expect.objectContaining({ type: 'click' }));
     expect(onClick.mock.calls.length).toBe(2);
   });
 
   it('should not toggle when clicked in a disabled state', () => {
     const onChange = jest.fn();
-    const wrapper = createSwitch({ disabled: true, checked: true, onChange });
-    expect(wrapper.exists('.checked')).toBeTruthy();
-    wrapper.simulate('click');
-    expect(wrapper.exists('.checked')).toBeTruthy();
+    const { getByRole } = createSwitch({ disabled: true, checked: true, onChange });
+    const switchNode = getByRole('switch');
+
+    expect(switchNode.getAttribute('aria-checked')).toBe('true');
+    fireEvent.click(switchNode);
+    expect(switchNode.getAttribute('aria-checked')).toBe('true');
     expect(onChange.mock.calls.length).toBe(0);
   });
 
   it('should support loading icon node', () => {
-    const wrapper = mount(<Switch loadingIcon={<span className="extra">loading</span>} />);
-    expect(wrapper.find('.extra').text()).toBe('loading');
+    const { container } = render(<Switch loadingIcon={<span className="extra">loading</span>} />);
+    expect(container.querySelector('.extra').textContent).toBe('loading');
   });
 
   it('focus()', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
     const handleFocus = jest.fn();
     const ref = React.createRef();
-    mount(<Switch ref={ref} onFocus={handleFocus} />, {
-      attachTo: container,
-    });
+    render(<Switch ref={ref} onFocus={handleFocus} />);
+
     ref.current.focus();
+    expect(document.activeElement).toBe(ref.current);
+    fireEvent.focus(ref.current);
     expect(handleFocus).toHaveBeenCalled();
   });
 
   it('blur()', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
     const handleBlur = jest.fn();
     const ref = React.createRef();
-    mount(<Switch ref={ref} onBlur={handleBlur} />, {
-      attachTo: container,
-    });
+    render(<Switch ref={ref} onBlur={handleBlur} />);
+
     ref.current.focus();
+    expect(document.activeElement).toBe(ref.current);
     ref.current.blur();
+    expect(document.activeElement).not.toBe(ref.current);
+    fireEvent.blur(ref.current);
     expect(handleBlur).toHaveBeenCalled();
   });
 
   describe('autoFocus', () => {
     it('basic', () => {
-      const container = document.createElement('div');
-      document.body.appendChild(container);
       const handleFocus = jest.fn();
-      mount(<Switch autoFocus onFocus={handleFocus} />, { attachTo: container });
+      const { getByRole } = render(<Switch autoFocus onFocus={handleFocus} />);
+      const switchNode = getByRole('switch');
+
+      expect(document.activeElement).toBe(switchNode);
+      fireEvent.focus(switchNode);
       expect(handleFocus).toHaveBeenCalled();
     });
 
     it('not work when disabled', () => {
-      const container = document.createElement('div');
-      document.body.appendChild(container);
       const handleFocus = jest.fn();
-      mount(<Switch autoFocus disabled onFocus={handleFocus} />, { attachTo: container });
+      render(<Switch autoFocus disabled onFocus={handleFocus} />);
       expect(handleFocus).not.toHaveBeenCalled();
     });
   });
 
   it('disabled', () => {
-    const wrapper = createSwitch({ disabled: true });
-    expect(wrapper.exists('.unchecked')).toBeTruthy();
-    wrapper.simulate('keydown', { keyCode: 39 });
-    expect(wrapper.exists('.unchecked')).toBeTruthy();
+    const { getByRole } = createSwitch({ disabled: true });
+    const switchNode = getByRole('switch');
+
+    expect(switchNode.getAttribute('aria-checked')).toBe('false');
+    keyDownWithWhich(switchNode, KeyCode.RIGHT);
+    expect(switchNode.getAttribute('aria-checked')).toBe('false');
   });
 
   it('onMouseUp', () => {
     const onMouseUp = jest.fn();
-    const wrapper = createSwitch({ onMouseUp });
-    wrapper.simulate('mouseup');
+    const { getByRole } = createSwitch({ onMouseUp });
+
+    fireEvent.mouseUp(getByRole('switch'));
     expect(onMouseUp).toHaveBeenCalled();
   });
 
   it('disabled should click not to change', () => {
     const onChange = jest.fn();
     const onClick = jest.fn();
-    const wrapper = createSwitch({ disabled: true, onChange, onClick, checked: true });
+    const { getByRole } = createSwitch({ disabled: true, onChange, onClick, checked: true });
 
-    wrapper.simulate('click');
+    fireEvent.click(getByRole('switch'));
     expect(onChange).not.toHaveBeenCalled();
   });
   it('support classnames and styles', () => {
-    const wrapper = createSwitch({
+    const { container } = createSwitch({
       classNames: { content: 'custom-content' },
       styles: { content: { background: 'red' } },
     });
-    const contentElement = wrapper.find('.custom-content').at(0);
-    expect(contentElement.exists()).toBe(true);
-    expect(contentElement.prop('style')).toEqual({ background: 'red' });
+    const contentElement = container.querySelector('.custom-content');
+
+    expect(contentElement).toBeTruthy();
+    expect(contentElement.style.background).toBe('red');
   });
 });


### PR DESCRIPTION
## 背景

antd 侧限制继续使用 rc 包的 `lib` / `es` 深路径导入，需要将 switch 中对 `@rc-component/util` 的内部路径依赖迁移到包根入口。

## 调整内容

- 升级 `@rc-component/father-plugin`，使用插件统一拦截 rc 包 `lib` / `es` 深路径导入。
- 升级 `@rc-component/util`，从 `@rc-component/util` 根入口导入 `KeyCode` 与 `useControlledState`。
- 将测试从 Enzyme 迁移到 Testing Library，避免继续升级 Enzyme adapter。
- 测试环境升级到 React 18，仅影响 dev/test，不调整 runtime peer 约束。

## 验证

- `npm test -- --runInBand`
- `npm run lint`
- `npm run compile`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 更新了核心依赖版本，包括工具库和开发工具链的升级。
  * 升级开发依赖至最新版本，改进了开发体验和构建性能。
  * 优化了模块导入方式以适配更新的依赖版本。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/switch/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->